### PR TITLE
removing babel from the project

### DIFF
--- a/bin/www.js
+++ b/bin/www.js
@@ -1,2 +1,1 @@
-require('babel/register');
-require('../app.js');
+require('../app.js')

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "homepage": "https://github.com/uwaseem/ChuckieNorrisieTwitterBot#readme",
   "dependencies": {
-    "babel": "^5.8.23",
     "express": "^4.13.3",
     "request": "^2.65.0",
     "twit": "^2.1.0",


### PR DESCRIPTION
Babel is not needed anymore in the newer versions of NodeJS. Removing that now.