### PR TITLE
removed npm install and run npm tsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "description": "Twitter bot that tweets random Chuck Norris jokes.",
   "main": "./dist/index.js",
   "scripts": {
-    "build": "rm -rf ./dist && tsc",
-    "start": "npm install && npm run build && node ./dist/index.js",
+    "build": "rm -rf ./dist && npm run tsc",
+    "start": "npm run build && node ./dist/index.js",
     "start-local": "heroku local",
     "test": "mocha -r ts-node/register test/**/*.test.ts",
+    "tsc": "tsc",
     "ts-standard": "ts-standard --fix"
   },
   "repository": {


### PR DESCRIPTION
## Description
Removed npm install. That should happen automatically.
Added tsc run script

## Motivation and Context
When deploying app to heroku, tsc is not found.
This is because heroku is trying to find global typescript.
https://stackoverflow.com/questions/48972663/how-do-i-compile-typescript-at-heroku-postinstall